### PR TITLE
Create a limit method

### DIFF
--- a/server.go
+++ b/server.go
@@ -71,6 +71,7 @@ func NewServerMux(o ServerOptions) http.Handler {
 
 	image := ImageMiddleware(o)
 	mux.Handle(join(o, "/resize"), image(Resize))
+	mux.Handle(join(o, "/limit"), image(Limit))
 	mux.Handle(join(o, "/enlarge"), image(Enlarge))
 	mux.Handle(join(o, "/extract"), image(Extract))
 	mux.Handle(join(o, "/crop"), image(Crop))


### PR DESCRIPTION
In order to provide a way to resize an image according to "limit" sizes, preserving ratio, we use the image size to detect the orientation & restrict the image accordingly